### PR TITLE
Automatically stop mining when stretch threshold is reached

### DIFF
--- a/blockchain/miner.py
+++ b/blockchain/miner.py
@@ -50,8 +50,6 @@ if __name__ == '__main__':
     else:
         node = "https://lambda-coin.herokuapp.com/api"
 
-    coins_mined = 0
-
     # Load or create ID
     f = open("my_id.txt", "r")
     id = f.read()
@@ -61,8 +59,17 @@ if __name__ == '__main__':
     if id == 'NONAME\n':
         print("ERROR: You must change your name in `my_id.txt`!")
         exit()
-    # Run forever until interrupted
-    while True:
+
+    # Grab the user's latest total from server
+    def mined():
+        r = requests.get(url=node + "/totals")
+        d = r.json()
+        return d['totals'][id]
+
+    coins_mined = mined()
+
+    # Run until you have 100 coins
+    while coins_mined < 100:
         # Get the last proof from the server
         r = requests.get(url=node + "/last_proof")
         data = r.json()
@@ -73,8 +80,9 @@ if __name__ == '__main__':
 
         r = requests.post(url=node + "/mine", json=post_data)
         data = r.json()
+        coins_mined = mined()
         if data.get('message') == 'New Block Forged':
-            coins_mined += 1
             print("Total coins mined: " + str(coins_mined))
         else:
             print(data.get('message'))
+

--- a/blockchain/miner.py
+++ b/blockchain/miner.py
@@ -61,12 +61,12 @@ if __name__ == '__main__':
         exit()
 
     # Grab the user's latest total from server
-    def mined():
+    def user_total():
         r = requests.get(url=node + "/totals")
         d = r.json()
         return d['totals'][id]
 
-    coins_mined = mined()
+    coins_mined = user_total()
 
     # Run until you have 100 coins
     while coins_mined < 100:
@@ -80,7 +80,7 @@ if __name__ == '__main__':
 
         r = requests.post(url=node + "/mine", json=post_data)
         data = r.json()
-        coins_mined = mined()
+        coins_mined = user_total()
         if data.get('message') == 'New Block Forged':
             print("Total coins mined: " + str(coins_mined))
         else:


### PR DESCRIPTION
@br80 @briandoyle81: This should cause all miners that a person has running to automatically stop mining once they've reached the 100 coin threshold for the blockchain stretch. That will prevent those people who have already reached that threshold (and therefore have nothing more to gain) from mining coins that could be mined by users that have valid miners, but have been less lucky or have code/hardware that's less efficient.